### PR TITLE
Add "optimisable" processed property

### DIFF
--- a/pyproprop/processed_property.py
+++ b/pyproprop/processed_property.py
@@ -84,7 +84,9 @@ def processed_property(name, **kwargs):
         if max_value is not None:
             check_max(value)
         if len_sequence is not None:
-            check_len(value)
+            check_len(value, len_sequence)
+        if optimisable:
+            value = process_optimisable(value)
         if post_method is not None:
             value = apply_method(value)
         setattr(self, storage_name, value)
@@ -257,13 +259,15 @@ def processed_property(name, **kwargs):
             return title_description
         return description.upper()
 
-    def check_len(value):
+    def check_len(value, len_sequence):
         """Enforces the set sequence length to be equal to a specified value.
 
         Parameters
         ----------
         value : obj
             Property object value for setting.
+        len_sequence : obj:`int`
+            Length of desired sequence.
 
         Raises
         ------

--- a/pyproprop/processed_property.py
+++ b/pyproprop/processed_property.py
@@ -8,8 +8,9 @@ reuse.
 """
 
 from numbers import Real
-import numpy as np
 from typing import Iterable
+
+import numpy as np
 
 
 __all__ = ["processed_property"]

--- a/pyproprop/processed_property.py
+++ b/pyproprop/processed_property.py
@@ -7,6 +7,8 @@ reuse.
 
 """
 
+from numbers import Real
+import numpy as np
 from typing import Iterable
 
 
@@ -42,6 +44,7 @@ def processed_property(name, **kwargs):
     max_value = kwargs.get("max")
     min_value = kwargs.get("min")
     exclusive = kwargs.get("exclusive", False)
+    optimisable = kwargs.get("optimisable", False)
     post_method = kwargs.get("method")
 
     @property
@@ -295,6 +298,81 @@ def processed_property(name, **kwargs):
         if optional and value is None:
             return None
         return post_method(value)
+
+    def process_optimisable(value):
+        """Processes properties flagged as `optimisable`.
+
+        Parameters
+        ----------
+        value : obj
+            Property object value for setting.
+
+        Returns
+        -------
+        `numbers.Real`
+            If a number is supplied by user.
+        `tuple`
+            If a set of valid bounds are supplied (see `check_bounds`).
+        `ValueError`
+            If supplied `Iterable` is not of length 2.
+        `Type Error`
+            If either supplied bounds are not of type `numbers.Real` or 
+            the single supplied value is not of type `numbers.Real`
+
+        """
+        if isinstance(value, Real):
+            return value
+        if isinstance(value, Iterable):
+            check_len(value, 2)
+            bounds = []
+            msg = (f"Both {name} bounds must be of type {Real}, instead got "
+                f"{value[0]} at index 0 (type {type(value[0])}) and "
+                f"{value[1]} at index 1 (type {type(value[1])}).")
+            for bound in value:
+                if not isinstance(bound, Real):
+                    raise TypeError(msg)
+                bounds.append(bound)
+            bounds = check_bounds(bounds)
+            return bounds
+        msg = (f"{name} must be a {Real} or {Iterable} of length 2, instead "
+            f"got {repr(type(value))}.")
+        raise TypeError(msg)
+
+    def check_bounds(bounds):
+        """Validates bounds for `optimisable` processed property.
+
+        Parameters
+        ----------
+        bounds : :obj:`Iterable`
+            `Iterable` of bounds to be validated.
+
+        Returns
+        -------
+        :obj:`numbers.Real`
+            If the first bound equals the second bound.
+        :obj:`tuple`
+            If the second bound exceeds the first bound.
+        `ValueError`
+            If the first bound exceeds the second bound.
+
+        """
+        lower_bound = bounds[0]
+        upper_bound = bounds[1]
+        try:
+            # Test if both bounds can be represented as signed 64-bit number.
+            np.asarray(bounds, dtype=np.int64)
+        except OverflowError:
+            msg = ("Individual bounds must be able to be represented as a "
+                   "signed 64-bit number, and hence must lie in the range "
+                   "(-9223372036854775808, 9223372036854775807).")
+            raise ValueError(msg)
+        if np.isclose(lower_bound, upper_bound):
+            return lower_bound
+        if lower_bound > upper_bound:
+            msg = (f"Lower bound ({lower_bound}) at index 0 must be less "
+                f"than upper bound ({upper_bound}) at index 1.")
+            raise ValueError(msg)
+        return tuple(bounds)
 
     return prop
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 numpy>=1.17
+typing>=3.7

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,6 +53,8 @@ def TestProcessedProperties():
 			type=int, default=_DEFAULT_INT, optional=True)
 		cast_string = processed_property("cast_string",
 			type=str, cast=True)
+		optimisable_property = processed_property("optimisable_property",
+			optimisable=True)
 
 		def __init__(self, *,
 			checked_type_int=None,
@@ -69,7 +71,8 @@ def TestProcessedProperties():
 			checked_iterable_allowed=None,
 			optional_prop=None,
 			optional_prop_with_default=None,
-			cast_string=None
+			cast_string=None,
+			optimisable_property=None
 		):
 
 			self.checked_type_int = checked_type_int
@@ -94,5 +97,7 @@ def TestProcessedProperties():
 			self.optional_prop = optional_prop
 			self.optional_prop_with_default = optional_prop_with_default
 			self.cast_string = cast_string
+			if optimisable_property is not None:
+				self.optimisable_property = optimisable_property
 
 	return TestProcessedProperties

--- a/tests/test_processed_property.py
+++ b/tests/test_processed_property.py
@@ -2,7 +2,7 @@ from typing import Iterable
 
 from hypothesis import given
 from hypothesis.strategies import (booleans, floats, integers, iterables,
-                                   lists, one_of, text)
+                                   lists, one_of, text, tuples)
 import numpy as np
 import pytest
 
@@ -205,3 +205,62 @@ def test_cast_to_string(TestProcessedProperties, integer, float_):
     test_instance = TestProcessedProperties(cast_string=float_)
     assert test_instance.cast_string == str(float_)
     assert isinstance(test_instance.cast_string, str) is True
+
+
+@given(value=one_of(integers(), floats(allow_nan=False)),
+       bounds=tuples(floats(allow_nan=False, min_value=-9.223372036854776e+18,
+                            max_value=9.223372036854776e+18),
+                     floats(allow_nan=False, min_value=-9.223372036854776e+18,
+                            max_value=9.223372036854776e+18)))
+def test_optimisable_arg_passing(TestProcessedProperties, value, bounds):
+    test_instance = TestProcessedProperties(optimisable_property=value)
+    assert test_instance.optimisable_property == value
+    if bounds[0] < bounds[1]:
+        test_instance = TestProcessedProperties(optimisable_property=bounds)
+        assert test_instance.optimisable_property == bounds
+    elif bounds[0] > bounds[1]:
+        with pytest.raises(ValueError):
+            test_instance = TestProcessedProperties(optimisable_property=bounds)
+    elif np.isclose(bounds[0], bounds[1]):
+        test_instance = TestProcessedProperties(optimisable_property=bounds)
+        assert test_instance.optimisable_property == bounds[0]
+
+
+@given(float_bounds=tuples(floats(allow_nan=False,
+                                  min_value=9.223372036854776e+18),
+                           floats(allow_nan=False,
+                                  max_value=-9.223372036854776e+18)),
+       integer_bounds=tuples(integers(min_value=9223372036854775807),
+                             integers(max_value=-9223372036854775808)))
+def test_optimisable_error_messaging_for_non_64_bit_bounds(
+        TestProcessedProperties, float_bounds, integer_bounds):
+    """Test error handling when optimisable bounds cannot represented as
+    signed 64-bit number."""
+    with pytest.raises(ValueError):
+        test_instance = TestProcessedProperties(optimisable_property=float_bounds)
+    with pytest.raises(ValueError):
+        test_instance = TestProcessedProperties(optimisable_property=integer_bounds)
+
+
+@given(short_string=text(max_size=1),
+       two_char_string=text(min_size=2, max_size=2),
+       long_string=text(min_size=3),
+       short_list=lists(integers(), min_size=0, max_size=1),
+       long_list=lists(integers(), min_size=3),
+       invalid_bounds=tuples(integers(), text()))
+def test_optimisable_error_handling(TestProcessedProperties, short_string,
+                                    two_char_string, long_string,
+                                    short_list, long_list, invalid_bounds):
+    """Tests error handling for properties flagged as `optimisable`."""
+    with pytest.raises(ValueError):
+        test_instance = TestProcessedProperties(optimisable_property=short_string)
+    with pytest.raises(TypeError):
+        test_instance = TestProcessedProperties(optimisable_property=two_char_string)
+    with pytest.raises(ValueError):
+        test_instance = TestProcessedProperties(optimisable_property=long_string)
+    with pytest.raises(ValueError):
+        test_instance = TestProcessedProperties(optimisable_property=short_list)
+    with pytest.raises(ValueError):
+        test_instance = TestProcessedProperties(optimisable_property=long_list)
+    with pytest.raises(TypeError):
+        test_instance = TestProcessedProperties(optimisable_property=invalid_bounds)

--- a/tests/test_processed_property.py
+++ b/tests/test_processed_property.py
@@ -1,6 +1,6 @@
 from typing import Iterable
 
-from hypothesis import given
+from hypothesis import given, example
 from hypothesis.strategies import (booleans, floats, integers, iterables,
                                    lists, one_of, text, tuples)
 import numpy as np
@@ -212,18 +212,19 @@ def test_cast_to_string(TestProcessedProperties, integer, float_):
                             max_value=9.223372036854776e+18),
                      floats(allow_nan=False, min_value=-9.223372036854776e+18,
                             max_value=9.223372036854776e+18)))
+@example(value=0, bounds=(-204797952.00000006, -204800000.00000006))
 def test_optimisable_arg_passing(TestProcessedProperties, value, bounds):
     test_instance = TestProcessedProperties(optimisable_property=value)
     assert test_instance.optimisable_property == value
-    if bounds[0] < bounds[1]:
+    if np.isclose(bounds[0], bounds[1]):
+        test_instance = TestProcessedProperties(optimisable_property=bounds)
+        assert test_instance.optimisable_property == bounds[0]
+    elif bounds[0] < bounds[1]:
         test_instance = TestProcessedProperties(optimisable_property=bounds)
         assert test_instance.optimisable_property == bounds
     elif bounds[0] > bounds[1]:
         with pytest.raises(ValueError):
             test_instance = TestProcessedProperties(optimisable_property=bounds)
-    elif np.isclose(bounds[0], bounds[1]):
-        test_instance = TestProcessedProperties(optimisable_property=bounds)
-        assert test_instance.optimisable_property == bounds[0]
 
 
 @given(float_bounds=tuples(floats(allow_nan=False,


### PR DESCRIPTION
This pull request enables a user to flag a processed property as `optimisable`. This enables the following use cases:

1. The user supplies a single value - `pyproprop` returns said value
2. The user supplies a valid* set of bounds - `pyproprop` returns said bounds as a `tuple`
3. The user supplies a set of equal bounds -  `pyproprop` returns one of the bounds as a single value.

*Upper bound exceeds lower bound