### PR TITLE
(Fix issue #3) Remove type casting of default values

### DIFF
--- a/pyproprop/processed_property.py
+++ b/pyproprop/processed_property.py
@@ -106,12 +106,11 @@ def processed_property(name, **kwargs):
         Returns
         -------
         Optional[obj]
-            The value is return if is already of the expected type. If the
-            value is None and the property has been specified as optional, None
-            is returned unless there is a default in which case the default is
-            returned and cast to the expected type. Finally the supplied value
-            is attempted to be cast to the specified type and if successful
-            this is returned.
+            The value is returned if is already of the expected type. If the
+            value is None and the property has been specified as optional,
+            `None` is returned unless there is a default in which case the
+            default is returned. Finally the supplied value is attempted to be
+            cast to the specified type and if successful this is returned.
 
         Raises
         ------

--- a/pyproprop/processed_property.py
+++ b/pyproprop/processed_property.py
@@ -123,7 +123,7 @@ def processed_property(name, **kwargs):
             return value
         elif optional and value is None:
             if default:
-                return expected_type(default)
+                return default
             else:
                 return None
         elif cast_to_type:


### PR DESCRIPTION
This pull request fixes issue #3, whereby user-supplied default values were being cast to an expected type, causing an error when used with 'uncastable' objects. This implements the fix and updates the relevant docstrings (a test already exists for this use case (`test_optional_default_object_return`, line 188 in `test_processed_property.py`).