### PR TITLE
Packaging bug fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.17
 sympy>=1.6
-titlecase>=1.1
+titlecase=2.0
 typing>=3.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.17
 sympy>=1.6
-titlecase=2.0
+titlecase==2.0
 typing>=3.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ project_urls =
     Source Code = https://github.com/brocksam/pyproprop
     Bug Tracker = https://github.com/brocksam/pyproprop/issues
 classifiers =
-    Development Status :: 5 - Production/Stable
+    Development Status :: 3 - Alpha
     Intended Audience :: Developers
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ python_requires = >=3.6
 install_requires = 
     numpy >=1.17
     sympy >=1.6
-    titlecase >=1.1
+    titlecase =2.0
     typing >=3.7
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pyproprop
-version = 0.4.5
+version = 0.4.6
 author = Sam Brockie
 author_email = sambrockie@icloud.com
 description = Package for aiding writing classes with lots of similar simple properties without the boilerplate

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ python_requires = >=3.6
 install_requires = 
     numpy >=1.17
     sympy >=1.6
-    titlecase =2.0
+    titlecase ==2.0
     typing >=3.7
 
 [options.extras_require]


### PR DESCRIPTION
This PR:
- Explicitly names the package as "pyproprop" in the `setup.cfg`.
- Places a hard requirement on Titlecase version 2.0.0 to avoid an error with the most recent release (https://github.com/ppannuto/python-titlecase/issues/82).