### PR TITLE
Fix packaging bug

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pyproprop
-version = 0.4.6
+version = 0.4.7
 author = Sam Brockie
 author_email = sambrockie@icloud.com
 description = Package for aiding writing classes with lots of similar simple properties without the boilerplate

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ keyword =
     type-casting
 
 [options]
+package = pyproprop
 python_requires = >=3.6
 install_requires = 
     numpy >=1.17


### PR DESCRIPTION
This PR:
- Explicitly names `pyproprop` as a package directory to fix a bug in which `import pyproprop` raises an `ImportError` after installation with pip.